### PR TITLE
Update styling of navbar to work on small screen sizes

### DIFF
--- a/assets/branding.sass
+++ b/assets/branding.sass
@@ -4,6 +4,7 @@ $medium-size: 1024px
 $large-size: 1280px
 $mini-only: "only screen and (max-width:#{$mini-size})"
 $small-up: "only screen and (min-width:#{$small-size})"
+$small-down: "only screen and (max-wdith:#{$small-size})"
 $medium-up: "only screen and (min-width:#{$medium-size})"
 $large-up: "only screen and (min-width:#{$large-size})"
 

--- a/components/NavBar.vue
+++ b/components/NavBar.vue
@@ -38,6 +38,9 @@
   height: 60px
   box-shadow: 0 0 1px rgba(#000, .25)
 
+  @media #{$small-down}
+    height: 90px
+
 .nav-bar__inner
   max-width: 1200px
   margin: 0 auto
@@ -47,6 +50,10 @@
   @media #{$small-up}
     padding-left: 30px
     padding-right: 30px
+
+  @media #{$small-down}
+    display: flex
+    flex-direction: column
 
 .nav-bar__home
   display: inline-block
@@ -78,6 +85,14 @@
   height: 40px
   line-height: 40px
 
+  @media #{$small-down}
+    display: flex
+    justify-content: center
+    align-items: center
+    right: 0
+    left: 0
+    top: 40px
+
   @media #{$small-up}
     right: 30px
 
@@ -85,6 +100,9 @@
     display: inline-block
     position: relative
     margin: 0 0 0 1em
+
+  li:first-of-type
+    margin: 0
 
   .nav-bar__subscribe-link
 


### PR DESCRIPTION
Changed styling of navbar on smaller and down size screens to put logo centered and menu centered below it. 

* Added small-down global css variable for smaller screen sizes
* On smaller screen sizes increase size of navbar to account for logo above menu
* On smaller screen sizes change layout of navbar to flex column so logo will be on top of menu
* On smaller screen sizes change menu to be flexbox layout that is centered horizontal and vertical
* On smaller screen sizes change margin on first item in menu to have zero margin which removes the margin-right thus knocking the entire menu from being truly centered
* On smaller screen sizes change  the menu to be 40px from top to allow for logo and to position menu full width on screen by setting left and right to 0 for absolute placement.