### PR TITLE
Add fix for input button ios

### DIFF
--- a/components/SubscribeContent.vue
+++ b/components/SubscribeContent.vue
@@ -103,6 +103,7 @@ export default {
   background: $color-green
   color: #fff
   font-weight: 600
+  -webkit-appearance: none
 
 .small
   display: block


### PR DESCRIPTION
The subscribe button on iOS is showing a default iOS button style. This is not how it should be, so I added a `-webkit-appearance: none` to the button. In this way it will fall back to all styling already set. 