### PR TITLE
Fix title and add pubDate to RSS feed

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -51,7 +51,8 @@ const create = async feed => {
 
   items.map(flattenIssue).forEach(issue => {
     feed.addItem({
-      title: issue.name,
+      title: `#${issue.issueNumber} - ${issue.title}`,
+      date: new Date(issue.publishedOn),
       id: issue.issueNumber,
       link: `https://news.vuejs.org/issues/${issue.issueNumber}`,
       description: issue.description,


### PR DESCRIPTION
As discussed [on Twitter](https://twitter.com/mikestreety/status/1344612564584583168) the RSS feed was missing a title and a pubDate.

Although not required (the RSS was "valid"), not having a date meant that whenever the feed was added to a reader, it would think all the articles were published on that day.

Also, without a title, it was not the most descriptive feed.

As a side note, I couldn't work out how to "generate" the RSS file (I've never used nuxt before). The only way I could see my changes was to delete the [static RSS file](https://github.com/vuejs/news.vuejs.org/blob/master/static/feed.xml) - i've not committed this change.

Also as another side note, I had to add the following to the `npm run dev` command in package JSON, as otherwise it didn't want to use localhost

```
  "scripts": {
    "dev": "nuxt --hostname localhost --port 3000",
```

Thanks